### PR TITLE
Production upgrade to CMSSW_12_3_5 (#4688)

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -94,7 +94,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_3_4_patch3"
+    'default': "CMSSW_12_3_5"
 }
 
 # Configure ScramArch
@@ -163,7 +163,8 @@ repackVersionOverride = {
     "CMSSW_12_3_2_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_4" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_3_5" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -184,7 +185,8 @@ expressVersionOverride = {
     "CMSSW_12_3_2_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_4" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_3_5" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams
@@ -238,7 +240,7 @@ addExpressConfig(tier0Config, "Express",
                                  "TkAlMinBias", "SiPixelCalZeroBias", "SiPixelCalSingleMuon",
                                  "PromptCalibProd", "PromptCalibProdSiStrip", "PromptCalibProdSiPixelAli",
                                  "PromptCalibProdSiStripGains", "PromptCalibProdSiStripGainsAAG", "PromptCalibProdSiPixel",
-                                 "PromptCalibProdSiPixelLorentzAngle", "PromptCalibProdSiStripHitEfficiency"
+                                 "PromptCalibProdSiPixelLA", "PromptCalibProdSiStripHitEff"
                                 ],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,
@@ -386,7 +388,7 @@ addExpressConfig(tier0Config, "ALCALumiPixelsCountsExpress",
                  archivalNode=None,
                  tapeNode=None,
                  dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
-                 diskNode=None)
+                 diskNode="T2_CH_CERN")
 
 
 #####################

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 346512 - 2021 pp
 # 349840 - 2022 CRAFT
 # 350966 - 2022 Splashes
-setInjectRuns(tier0Config, [352493,349840])
+setInjectRuns(tier0Config, [349840,352503])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_3_4_patch3"
+    'default': "CMSSW_12_3_5"
 }
 
 # Configure ScramArch
@@ -175,7 +175,8 @@ repackVersionOverride = {
     "CMSSW_12_3_2_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_4" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_3_5" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -209,7 +210,8 @@ expressVersionOverride = {
     "CMSSW_12_3_2_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_4" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_3_5" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams
@@ -261,7 +263,7 @@ addExpressConfig(tier0Config, "Express",
                                  "TkAlMinBias", "SiPixelCalZeroBias", "SiPixelCalSingleMuon",
                                  "PromptCalibProd", "PromptCalibProdSiStrip", "PromptCalibProdSiPixelAli",
                                  "PromptCalibProdSiStripGains", "PromptCalibProdSiStripGainsAAG", "PromptCalibProdSiPixel",
-                                 "PromptCalibProdSiPixelLorentzAngle", "PromptCalibProdSiStripHitEfficiency"
+                                 "PromptCalibProdSiPixelLA", "PromptCalibProdSiStripHitEff"
                                 ],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,


### PR DESCRIPTION
* Production and Replay configuration for CMSSW_12_3_5

* Update modified names of ALCARECO

Co-authored-by: Fabio Cossutti <fabio.cossutti@ts.infn.it>

# Replay Request

**Requestor**  
Team or person that requests this replay

**Describe the configuration**  
* Release: 
* Run: 
* GTs:
   * expressGlobalTag: 
   * promptrecoGlobalTag:
   * alcap0GlobalTag:
* Additional changes:

**Purpose of the test**  
A replay test is costly, both in computational and human resources. Please describe the reason why this test is needed.

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
